### PR TITLE
Add Drink Counter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Drink Counter Integration
+
+This is a custom integration for [Home Assistant](https://www.home-assistant.io/) distributed via HACS.
+
+The integration allows you to manage drink tallies for multiple users. You can define drinks with prices and increment counters using a service call.
+
+## Features
+
+- Configure users and drinks via the UI (comma separated format `drink=price`).
+- Sensor entities for each drink and a sensor showing the total amount a user has to pay.
+- Button entity to reset all counters for a user.
+- Service `drink_counter.add_drink` to add a drink for a user.
+
+## Installation
+
+1. Add this repository to HACS as a custom repository.
+2. Install the **Drink Counter** integration.
+3. Restart Home Assistant and add the integration via the integrations page.
+
+## Usage
+
+After adding a user, call the service `drink_counter.add_drink` with parameters `user` and `drink` to increment the counter. Use the reset button entity to reset all counters.

--- a/custom_components/drink_counter/__init__.py
+++ b/custom_components/drink_counter/__init__.py
@@ -1,0 +1,62 @@
+"""Drink Counter integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers import service
+
+from .const import DOMAIN, SERVICE_ADD_DRINK, SERVICE_RESET_COUNTERS, ATTR_USER, ATTR_DRINK
+
+PLATFORMS: list[str] = ["sensor", "button"]
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up via YAML is not supported."""
+    hass.data.setdefault(DOMAIN, {})
+
+    async def add_drink_service(call):
+        user = call.data[ATTR_USER]
+        drink = call.data[ATTR_DRINK]
+        for entry_id, data in hass.data[DOMAIN].items():
+            if data["entry"].data.get("user") == user:
+                counts = data.setdefault("counts", {})
+                counts[drink] = counts.get(drink, 0) + 1
+                for sensor in data.get("sensors", []):
+                    await sensor.async_update_state()
+                break
+
+    async def reset_counters_service(call):
+        user = call.data.get(ATTR_USER)
+        for entry_id, data in hass.data[DOMAIN].items():
+            if user is None or data["entry"].data.get("user") == user:
+                data["counts"] = {drink: 0 for drink in data["entry"].data.get("drinks", {})}
+                for sensor in data.get("sensors", []):
+                    await sensor.async_update_state()
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ADD_DRINK,
+        add_drink_service,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_RESET_COUNTERS,
+        reset_counters_service,
+    )
+
+    return True
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    hass.data[DOMAIN].setdefault(entry.entry_id, {"entry": entry, "counts": {}})
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unloaded

--- a/custom_components/drink_counter/button.py
+++ b/custom_components/drink_counter/button.py
@@ -1,0 +1,29 @@
+"""Buttons for Drink Counter."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, SERVICE_RESET_COUNTERS, CONF_USER
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    async_add_entities([ResetButton(hass, entry)])
+
+
+class ResetButton(ButtonEntity):
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._attr_name = f"{entry.data[CONF_USER]} Reset"
+        self._attr_unique_id = f"{entry.entry_id}_reset"
+
+    async def async_press(self) -> None:
+        await self._hass.services.async_call(
+            DOMAIN,
+            SERVICE_RESET_COUNTERS,
+            {"user": self._entry.data[CONF_USER]},
+            blocking=True,
+        )

--- a/custom_components/drink_counter/config_flow.py
+++ b/custom_components/drink_counter/config_flow.py
@@ -1,0 +1,80 @@
+"""Config flow for Drink Counter."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from .const import DOMAIN, CONF_USER, CONF_DRINKS
+
+
+def _parse_drinks(value: str) -> dict[str, float]:
+    drinks: dict[str, float] = {}
+    if not value:
+        return drinks
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" not in part:
+            raise ValueError
+        name, price = part.split("=", 1)
+        drinks[name.strip()] = float(price)
+    return drinks
+
+
+class DrinkCounterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            try:
+                drinks = _parse_drinks(user_input[CONF_DRINKS])
+            except ValueError:
+                errors[CONF_DRINKS] = "invalid_drinks"
+            if not errors:
+                return self.async_create_entry(
+                    title=user_input[CONF_USER],
+                    data={CONF_USER: user_input[CONF_USER], CONF_DRINKS: drinks},
+                )
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USER): str,
+                vol.Required(CONF_DRINKS): str,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return DrinkCounterOptionsFlowHandler(config_entry)
+
+
+class DrinkCounterOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            try:
+                drinks = _parse_drinks(user_input[CONF_DRINKS])
+            except ValueError:
+                errors[CONF_DRINKS] = "invalid_drinks"
+            if not errors:
+                return self.async_create_entry(title="", data={CONF_DRINKS: drinks})
+        current = ",".join(
+            f"{name}={price}" for name, price in self.config_entry.data.get(CONF_DRINKS, {}).items()
+        )
+        schema = vol.Schema(
+            {vol.Required(CONF_DRINKS, default=current): str}
+        )
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/drink_counter/const.py
+++ b/custom_components/drink_counter/const.py
@@ -1,0 +1,11 @@
+DOMAIN = "drink_counter"
+
+CONF_USER = "user"
+CONF_DRINKS = "drinks"
+CONF_PRICE = "price"
+
+ATTR_USER = "user"
+ATTR_DRINK = "drink"
+
+SERVICE_ADD_DRINK = "add_drink"
+SERVICE_RESET_COUNTERS = "reset_counters"

--- a/custom_components/drink_counter/manifest.json
+++ b/custom_components/drink_counter/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "drink_counter",
+  "name": "Drink Counter",
+  "documentation": "https://github.com/example/ha-drink-counter",
+  "version": "0.1.0",
+  "requirements": [],
+  "codeowners": []
+}

--- a/custom_components/drink_counter/sensor.py
+++ b/custom_components/drink_counter/sensor.py
@@ -1,0 +1,61 @@
+"""Sensors for Drink Counter."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, CONF_USER, CONF_DRINKS
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    data = hass.data[DOMAIN][entry.entry_id]
+    user = entry.data[CONF_USER]
+    drinks = entry.data[CONF_DRINKS]
+    sensors = []
+    for drink_name, price in drinks.items():
+        sensors.append(DrinkCounterSensor(hass, entry, drink_name, price))
+    sensors.append(TotalAmountSensor(hass, entry))
+    async_add_entities(sensors)
+    data.setdefault("sensors", []).extend(sensors)
+
+
+class DrinkCounterSensor(Entity):
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, drink: str, price: float) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._drink = drink
+        self._price = price
+        self._attr_name = f"{entry.data[CONF_USER]} {drink} Count"
+        self._attr_unique_id = f"{entry.entry_id}_{drink}_count"
+
+    async def async_update_state(self):
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self):
+        counts = self._hass.data[DOMAIN][self._entry.entry_id].setdefault("counts", {})
+        return counts.get(self._drink, 0)
+
+
+class TotalAmountSensor(Entity):
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._attr_name = f"{entry.data[CONF_USER]} Amount Due"
+        self._attr_unique_id = f"{entry.entry_id}_amount_due"
+        self._attr_unit_of_measurement = "EUR"
+
+    async def async_update_state(self):
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self):
+        data = self._hass.data[DOMAIN][self._entry.entry_id]
+        counts = data.setdefault("counts", {})
+        total = 0.0
+        for drink, price in self._entry.data[CONF_DRINKS].items():
+            total += counts.get(drink, 0) * price
+        return round(total, 2)

--- a/custom_components/drink_counter/services.yaml
+++ b/custom_components/drink_counter/services.yaml
@@ -1,0 +1,18 @@
+add_drink:
+  name: Add drink
+  description: Increment drink counter for a user
+  fields:
+    user:
+      description: User name
+      example: Alice
+    drink:
+      description: Drink name
+      example: beer
+reset_counters:
+  name: Reset counters
+  description: Reset counters for a user. If no user is specified, reset all.
+  fields:
+    user:
+      description: User name
+      example: Alice
+      required: false

--- a/custom_components/drink_counter/translations/de.json
+++ b/custom_components/drink_counter/translations/de.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Drink Counter konfigurieren",
+        "description": "Benutzer und Getränke mit Preisen hinzufügen (Getränk=Preis)",
+        "data": {
+          "user": "Benutzername",
+          "drinks": "Getränke"
+        }
+      }
+    },
+    "error": {
+      "invalid_drinks": "Ungültiges Getränkeformat"
+    },
+    "options": {
+      "step": {
+        "init": {
+          "title": "Getränke",
+          "description": "Getränke für diesen Benutzer aktualisieren",
+          "data": {
+            "drinks": "Getränke"
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/drink_counter/translations/en.json
+++ b/custom_components/drink_counter/translations/en.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Configure Drink Counter",
+        "description": "Add a user and drinks with prices separated by comma (drink=price)",
+        "data": {
+          "user": "User name",
+          "drinks": "Drinks"
+        }
+      }
+    },
+    "error": {
+      "invalid_drinks": "Invalid drinks format"
+    },
+    "options": {
+      "step": {
+        "init": {
+          "title": "Drinks",
+          "description": "Update drinks for this user",
+          "data": {
+            "drinks": "Drinks"
+          }
+        }
+      }
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "Drink Counter",
+  "content_in_root": false,
+  "domains": ["sensor", "button"],
+  "country": "DE",
+  "homeassistant": "2023.0.0"
+}


### PR DESCRIPTION
## Summary
- implement custom `drink_counter` integration with config flow
- add sensors for drink counts and amount due
- add reset button and services
- provide HACS metadata and translations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc1fc6358832eb6da51c66d44782a