### PR TITLE
Enable UI setup for Drink Counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The integration allows you to manage drink tallies for multiple users. You can d
 1. Add this repository to HACS as a custom repository.
 2. Install the **Drink Counter** integration.
 3. Restart Home Assistant and add the integration via the integrations page.
+   The integration is fully configurable through the UI.
 
 ## Usage
 

--- a/custom_components/drink_counter/manifest.json
+++ b/custom_components/drink_counter/manifest.json
@@ -2,7 +2,8 @@
   "domain": "drink_counter",
   "name": "Drink Counter",
   "documentation": "https://github.com/example/ha-drink-counter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "requirements": [],
+  "config_flow": true,
   "codeowners": []
 }


### PR DESCRIPTION
## Summary
- allow adding the integration via the config flow by enabling `config_flow`
- document UI configuration in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cc39d9d2c832eaec6a5e9407f0712