### PR TITLE
Fix drink_counter service errors

### DIFF
--- a/custom_components/drink_counter/__init__.py
+++ b/custom_components/drink_counter/__init__.py
@@ -27,6 +27,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         drink = call.data[ATTR_DRINK]
         amount = call.data.get("amount", 1)
         for entry_id, data in hass.data[DOMAIN].items():
+            if "entry" not in data:
+                continue
             if data["entry"].data.get("user") == user:
                 counts = data.setdefault("counts", {})
                 counts[drink] = counts.get(drink, 0) + amount
@@ -41,6 +43,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         user = call.data.get(ATTR_USER)
         drinks = hass.data[DOMAIN].get("drinks", {})
         for entry_id, data in hass.data[DOMAIN].items():
+            if "entry" not in data:
+                continue
             if user is None or data["entry"].data.get("user") == user:
                 data["counts"] = {drink: 0 for drink in drinks}
                 for sensor in data.get("sensors", []):


### PR DESCRIPTION
## Summary
- handle `hass.data[DOMAIN]` keys that don't contain config entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cca52e334832eabad9b180ee387b0