### PR TITLE
Add automatic price list user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ When the first user is created you will be asked to enter the available drinks. 
 
 ## Price List and Sensors
 
-All drinks are stored in a single price list. Create a user named `Preisliste`
-to expose one price sensor per drink. Regular users only get count and total
-amount sensors while the `Preisliste` user holds the `<Preisliste> <drink>
-Price` sensors. You can edit the drinks and their prices at any time from the
+All drinks are stored in a single price list. A dedicated user named
+`Preisliste` is automatically created when the first user is set up. This user
+exposes one price sensor per drink while regular users only get count and total
+amount sensors. You can edit the drinks and their prices at any time from the
 integration options.

--- a/custom_components/drink_counter/config_flow.py
+++ b/custom_components/drink_counter/config_flow.py
@@ -13,6 +13,7 @@ from .const import (
     CONF_DRINKS,
     CONF_DRINK,
     CONF_PRICE,
+    PRICE_LIST_USER,
 )
 
 
@@ -64,6 +65,20 @@ class DrinkCounterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if user_input.get("add_more"):
                 return await self.async_step_add_drink()
             self.hass.data.setdefault(DOMAIN, {})["drinks"] = self._drinks
+
+            has_price_user = any(
+                entry.data.get(CONF_USER) == PRICE_LIST_USER
+                for entry in self.hass.config_entries.async_entries(DOMAIN)
+            )
+            if not has_price_user:
+                self.hass.async_create_task(
+                    self.hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context={"source": config_entries.SOURCE_IMPORT},
+                        data={CONF_USER: PRICE_LIST_USER},
+                    )
+                )
+
             return self.async_create_entry(
                 title=self._user,
                 data={CONF_USER: self._user, CONF_DRINKS: self._drinks},


### PR DESCRIPTION
## Summary
- auto-create a `Preisliste` user when the first user sets up drinks
- document automatic creation of the price list user

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cdc4009a0832ea8cb2dfdfe9a4b5c