### PR TITLE
Update integration logo

### DIFF
--- a/custom_components/drink_counter/logo.svg
+++ b/custom_components/drink_counter/logo.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect x="14" y="8" width="32" height="48" rx="4" ry="4" fill="#ffcc00" stroke="#000" stroke-width="2"/>
-  <rect x="46" y="18" width="6" height="28" rx="2" ry="2" fill="#ffcc00" stroke="#000" stroke-width="2"/>
-  <rect x="18" y="20" width="24" height="24" fill="#ffffff" opacity="0.5"/>
-</svg>

--- a/custom_components/drink_counter/manifest.json
+++ b/custom_components/drink_counter/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.1.2",
   "requirements": [],
   "icon": "mdi:glass-mug",
-  "logo": "logo.svg",
+  "logo": "icon.png",
   "config_flow": true,
   "codeowners": []
 }


### PR DESCRIPTION
## Summary
- use `icon.png` for the integration logo so HACS and the integration share the same image
- remove old `logo.svg`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687ce1309950832e87f290d1cec53982