### PR TITLE
Add repo logo to HACS metadata

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,7 @@
   "content_in_root": false,
   "domains": ["sensor", "button"],
   "country": "DE",
-  "homeassistant": "2023.0.0"
+  "homeassistant": "2023.0.0",
+  "image": "https://github.com/Spider19996/ha-drink-counter/raw/main/custom_components/drink_counter/logo.png",
+  "render_readme": true
 }


### PR DESCRIPTION
## Summary
- show the integration logo in HACS

## Testing
- `pytest -q`
- `flake8` *(fails: found unused imports and E501 line length issues)*

------
https://chatgpt.com/codex/tasks/task_e_687ce6d61fa4832ebd0bcae8a0eb891a