### PR TITLE
Change adjust function to set count

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The integration allows you to manage drink tallies for multiple users. Drinks ar
 - Button entity to reset all counters for a user.
 - Service `drink_counter.add_drink` to add a drink for a user.
 - Service `drink_counter.remove_drink` to remove a drink for a user.
-- Service `drink_counter.adjust_count` to increase or decrease a drink count.
+- Service `drink_counter.adjust_count` to set a drink count to a specific value.
 
 ## Installation
 
@@ -22,7 +22,7 @@ The integration allows you to manage drink tallies for multiple users. Drinks ar
 
 ## Usage
 
-When the first user is created you will be asked to enter the available drinks. All further users will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `drink_counter.add_drink` with parameters `user` and `drink` to increment the counter or `drink_counter.adjust_count` with `amount` to change it. To decrement by one call `drink_counter.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters.
+When the first user is created you will be asked to enter the available drinks. All further users will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `drink_counter.add_drink` with parameters `user` and `drink` to increment the counter. Use `drink_counter.adjust_count` with `count` to set an exact value. To decrement by one call `drink_counter.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters.
 
 ## Price List and Sensors
 

--- a/custom_components/drink_counter/services.yaml
+++ b/custom_components/drink_counter/services.yaml
@@ -20,7 +20,7 @@ remove_drink:
       example: beer
 adjust_count:
   name: Adjust count
-  description: Increase or decrease drink count for a user
+  description: Set drink count for a user
   fields:
     user:
       description: User name
@@ -28,9 +28,9 @@ adjust_count:
     drink:
       description: Drink name
       example: beer
-    amount:
-      description: Amount to add (use negative to subtract)
-      example: -1
+    count:
+      description: Desired drink count
+      example: 3
 reset_counters:
   name: Reset counters
   description: Reset counters for a user. If no user is specified, reset all.


### PR DESCRIPTION
## Summary
- modify adjust_count service to set a count instead of adding/subtracting
- update add/remove services accordingly
- document new behaviour in README and services.yaml

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0507d3e8832ea8bcb0523cac2180