### PR TITLE
Auto reload entries when drinks updated

### DIFF
--- a/custom_components/drink_counter/config_flow.py
+++ b/custom_components/drink_counter/config_flow.py
@@ -203,6 +203,7 @@ class DrinkCounterOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_DRINKS: self._drinks,
             }
             self.hass.config_entries.async_update_entry(entry, data=data)
+            await self.hass.config_entries.async_reload(entry.entry_id)
         self.hass.data.setdefault(DOMAIN, {})["drinks"] = self._drinks
         for data in self.hass.data.get(DOMAIN, {}).values():
             for sensor in data.get("sensors", []):


### PR DESCRIPTION
## Summary
- automatically reload all entries when drinks are changed in options so new sensors appear without manual reload

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d07fb2780832e9e164861414ecea4