### PR TITLE
Fix negative drink count handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The integration allows you to manage drink tallies for multiple users. Drinks ar
 - Service `drink_counter.add_drink` to add a drink for a user.
 - Service `drink_counter.remove_drink` to remove a drink for a user.
 - Service `drink_counter.adjust_count` to set a drink count to a specific value.
+- Counters cannot go below zero when removing drinks.
 
 ## Installation
 

--- a/custom_components/drink_counter/__init__.py
+++ b/custom_components/drink_counter/__init__.py
@@ -26,7 +26,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def adjust_count_service(call):
         user = call.data[ATTR_USER]
         drink = call.data[ATTR_DRINK]
-        count = call.data.get("count", 0)
+        count = max(0, call.data.get("count", 0))
         for entry_id, data in hass.data[DOMAIN].items():
             if "entry" not in data:
                 continue
@@ -60,6 +60,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if data["entry"].data.get("user") == user:
                 counts = data.setdefault("counts", {})
                 new_count = counts.get(drink, 0) - 1
+                if new_count < 0:
+                    new_count = 0
                 counts[drink] = new_count
                 for sensor in data.get("sensors", []):
                     await sensor.async_update_state()

--- a/custom_components/drink_counter/manifest.json
+++ b/custom_components/drink_counter/manifest.json
@@ -2,7 +2,7 @@
   "domain": "drink_counter",
   "name": "Drink Counter",
   "documentation": "https://github.com/example/ha-drink-counter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "requirements": [],
   "icon": "mdi:glass-mug",
   "config_flow": true,


### PR DESCRIPTION
## Summary
- prevent `remove_drink` service from making counts negative
- clamp negative values in `adjust_count` service
- document the non-negative behavior
- bump integration version to 0.1.3

## Testing
- `python -m py_compile custom_components/drink_counter/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687d0ea32478832ebed8e1d5496ba312