### PR TITLE
Refactor to single config entry with multiple users

### DIFF
--- a/custom_components/drink_counter/button.py
+++ b/custom_components/drink_counter/button.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from .const import (
     DOMAIN,
     SERVICE_RESET_COUNTERS,
-    CONF_USER,
+    CONF_USERS,
     PRICE_LIST_USER,
 )
 
@@ -17,21 +17,26 @@ from .const import (
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
-    if entry.data[CONF_USER] != PRICE_LIST_USER:
-        async_add_entities([ResetButton(hass, entry)])
+    buttons = []
+    for user in entry.data.get(CONF_USERS, []):
+        if user != PRICE_LIST_USER:
+            buttons.append(ResetButton(hass, entry, user))
+    if buttons:
+        async_add_entities(buttons)
 
 
 class ResetButton(ButtonEntity):
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, user: str) -> None:
         self._hass = hass
         self._entry = entry
-        self._attr_name = f"{entry.data[CONF_USER]} Reset"
-        self._attr_unique_id = f"{entry.entry_id}_reset"
+        self._user = user
+        self._attr_name = f"{user} Reset"
+        self._attr_unique_id = f"{entry.entry_id}_{user}_reset"
 
     async def async_press(self) -> None:
         await self._hass.services.async_call(
             DOMAIN,
             SERVICE_RESET_COUNTERS,
-            {"user": self._entry.data[CONF_USER]},
+            {"user": self._user},
             blocking=True,
         )

--- a/custom_components/drink_counter/config_flow.py
+++ b/custom_components/drink_counter/config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.core import callback
 from .const import (
     DOMAIN,
     CONF_USER,
+    CONF_USERS,
     CONF_DRINKS,
     CONF_DRINK,
     CONF_PRICE,
@@ -36,7 +37,7 @@ def _parse_drinks(value: str) -> dict[str, float]:
 class DrinkCounterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         self._user: str | None = None
@@ -50,19 +51,38 @@ class DrinkCounterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._user = user_input.get(CONF_USER)
         self._drinks = user_input.get(CONF_DRINKS, {})
         self._free_amount = float(user_input.get(CONF_FREE_AMOUNT, 0.0))
-        return self.async_create_entry(title=self._user, data=user_input)
+        return self.async_create_entry(
+            title="Drink Counter",
+            data={
+                CONF_USERS: [self._user, PRICE_LIST_USER],
+                CONF_DRINKS: self._drinks,
+                CONF_FREE_AMOUNT: self._free_amount,
+            },
+        )
 
     async def async_step_user(self, user_input=None):
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        if entries:
+            entry = entries[0]
+            if user_input is not None:
+                self._user = user_input[CONF_USER]
+                users = list(entry.data.get(CONF_USERS, []))
+                if self._user in users:
+                    return self.async_abort(reason="user_exists")
+                users.append(self._user)
+                data = {
+                    CONF_USERS: users,
+                    CONF_DRINKS: entry.data.get(CONF_DRINKS, {}),
+                    CONF_FREE_AMOUNT: entry.data.get(CONF_FREE_AMOUNT, 0.0),
+                }
+                self.hass.config_entries.async_update_entry(entry, data=data)
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_create_entry(title="", data={})
+            schema = vol.Schema({vol.Required(CONF_USER): str})
+            return self.async_show_form(step_id="user", data_schema=schema)
+
         if user_input is not None:
             self._user = user_input[CONF_USER]
-            entries = self.hass.config_entries.async_entries(DOMAIN)
-            for entry in entries:
-                if CONF_DRINKS in entry.data:
-                    self._drinks = entry.data[CONF_DRINKS]
-                    return self.async_create_entry(
-                        title=self._user,
-                        data={CONF_USER: self._user},
-                    )
             return await self.async_step_add_drink()
 
         schema = vol.Schema({vol.Required(CONF_USER): str})
@@ -76,27 +96,10 @@ class DrinkCounterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if user_input.get("add_more"):
                 return await self.async_step_add_drink()
             self.hass.data.setdefault(DOMAIN, {})["drinks"] = self._drinks
-
-            has_price_user = any(
-                entry.data.get(CONF_USER) == PRICE_LIST_USER
-                for entry in self.hass.config_entries.async_entries(DOMAIN)
-            )
-            if not has_price_user:
-                self.hass.async_create_task(
-                    self.hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": config_entries.SOURCE_IMPORT},
-                        data={
-                            CONF_USER: PRICE_LIST_USER,
-                            CONF_FREE_AMOUNT: 0.0,
-                        },
-                    )
-                )
-
             return self.async_create_entry(
-                title=self._user,
+                title="Drink Counter",
                 data={
-                    CONF_USER: self._user,
+                    CONF_USERS: [self._user, PRICE_LIST_USER],
                     CONF_DRINKS: self._drinks,
                     CONF_FREE_AMOUNT: 0.0,
                 },
@@ -124,10 +127,12 @@ class DrinkCounterOptionsFlowHandler(config_entries.OptionsFlow):
         self.config_entry = config_entry
         self._drinks: dict[str, float] = {}
         self._free_amount: float = 0.0
+        self._users: list[str] = []
 
     async def async_step_init(self, user_input=None):
         self._drinks = self.hass.data.get(DOMAIN, {}).get("drinks", {}).copy()
         self._free_amount = self.hass.data.get(DOMAIN, {}).get("free_amount", 0.0)
+        self._users = list(self.config_entry.data.get(CONF_USERS, []))
         return await self.async_step_menu()
 
     async def async_step_menu(self, user_input=None):
@@ -139,6 +144,10 @@ class DrinkCounterOptionsFlowHandler(config_entries.OptionsFlow):
                 return await self.async_step_remove_drink()
             if action == "edit":
                 return await self.async_step_edit_price()
+            if action == "add_user":
+                return await self.async_step_add_user()
+            if action == "remove_user":
+                return await self.async_step_remove_user()
             if action == "free_amount":
                 return await self.async_step_set_free_amount()
             if action == "finish":
@@ -146,7 +155,15 @@ class DrinkCounterOptionsFlowHandler(config_entries.OptionsFlow):
         schema = vol.Schema(
             {
                 vol.Required("action"): vol.In(
-                    ["add", "remove", "edit", "free_amount", "finish"]
+                    [
+                        "add",
+                        "remove",
+                        "edit",
+                        "add_user",
+                        "remove_user",
+                        "free_amount",
+                        "finish",
+                    ]
                 ),
             }
         )
@@ -223,6 +240,43 @@ class DrinkCounterOptionsFlowHandler(config_entries.OptionsFlow):
         )
         return self.async_show_form(step_id="set_free_amount", data_schema=schema)
 
+    async def async_step_add_user(self, user_input=None):
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            if user not in self._users:
+                self._users.append(user)
+            if user_input.get("add_more"):
+                return await self.async_step_add_user()
+            return await self.async_step_menu()
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USER): str,
+                vol.Optional("add_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="add_user", data_schema=schema)
+
+    async def async_step_remove_user(self, user_input=None):
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            if user in self._users and user != PRICE_LIST_USER:
+                self._users.remove(user)
+            if user_input.get("remove_more") and len(self._users) > 1:
+                return await self.async_step_remove_user()
+            return await self.async_step_menu()
+
+        selectable = [u for u in self._users if u != PRICE_LIST_USER]
+        if not selectable:
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USER): vol.In(selectable),
+                vol.Optional("remove_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="remove_user", data_schema=schema)
+
     async def _update_drinks(self):
         # Update global drinks list before reloading entries so that new
         # sensors are created with the latest values during setup.
@@ -231,7 +285,7 @@ class DrinkCounterOptionsFlowHandler(config_entries.OptionsFlow):
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             data = {
-                CONF_USER: entry.data[CONF_USER],
+                CONF_USERS: self._users,
                 CONF_DRINKS: self._drinks,
                 CONF_FREE_AMOUNT: self._free_amount,
             }
@@ -244,6 +298,7 @@ class DrinkCounterOptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_create_entry(
             title="",
             data={
+                CONF_USERS: self._users,
                 CONF_DRINKS: self._drinks,
                 CONF_FREE_AMOUNT: self._free_amount,
             },

--- a/custom_components/drink_counter/const.py
+++ b/custom_components/drink_counter/const.py
@@ -1,6 +1,7 @@
 DOMAIN = "drink_counter"
 
 CONF_USER = "user"
+CONF_USERS = "users"
 CONF_DRINKS = "drinks"
 CONF_DRINK = "drink"
 CONF_PRICE = "price"


### PR DESCRIPTION
## Summary
- update constants for user list
- revise config flow to store all users in one entry
- update service handlers to track counts per user
- adjust sensors and buttons to handle multiple users

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d31c7780c832ebb05104020fe7918